### PR TITLE
Dzil5

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::Prepender
 
 {{$NEXT}}
+ - On Dzil 5, skip files with encoding eq 'bytes' (kent fredric)
 
 1.112280  2011-08-16 19:22:55 Europe/Paris
  - allow to skip files (randy stauner)

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,9 @@ author  = Jerome Quelin
 license = Perl_5
 copyright_holder = Jerome Quelin
 copyright_year   = 2009
-
+[Bootstrap::lib]
+try_built = 1
+;fallback  = 0
 ; -- static meta-information
 [MetaResources]
 x_MailingList = http://www.listbox.com/subscribe/?list_id=139292

--- a/lib/Dist/Zilla/Plugin/Prepender.pm
+++ b/lib/Dist/Zilla/Plugin/Prepender.pm
@@ -30,6 +30,7 @@ has _skips => (
     default    => sub { [] },
 );
 
+our $DZIL_5 = eval { Dist::Zilla->VERSION(5.000) };
 
 # -- public methods
 
@@ -39,6 +40,8 @@ sub munge_file {
     foreach my $skip ( $self->_skips ){
         return if $file->name =~ $skip;
     }
+
+    return if $DZIL_5 and $file->encoding eq 'bytes';
 
     return $self->_munge_perl($file) if $file->name    =~ /\.(?:pm|pl)$/i;
     return $self->_munge_perl($file) if $file->content =~ /^#!(?:.*)perl(?:$|\s)/;


### PR DESCRIPTION
2 Miscelaneous fixes to make `[Prepender]` work on Dzil 5.

Note: You can probably safely build and release this on Dzil 4 if you remove the `[Encoding]` plugin.

However, as soon as you upgrade to `Dzil 5`, you will need that and be using a patched version of this plugin ( for which, the provided `[Bootstrap::lib]` configuration will solve.